### PR TITLE
Suggestion to amend readme with inserting a package dependency instead of replacing it

### DIFF
--- a/host/composer.json
+++ b/host/composer.json
@@ -10,8 +10,6 @@
     "require": {
         "php": "^7.3|^8.0",
         "darkaonline/l5-swagger": "^8.0",
-        "escolalms/courses": "dev-master",
-        "escolalms/headless-h5p": "dev-master",
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
@@ -62,15 +60,5 @@
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
         ]
-    },
-    "repositories": {
-        "escolalms/headless-h5p": {
-            "type": "path",
-            "url": "../packages/headless-h5p"
-        },
-        "escolalms/courses": {
-            "type": "path",
-            "url": "../packages/courses"
-        }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -27,42 +27,11 @@ Repeat those steps for each package
 
 1. Clone your package to a folder inside this repo, in `packages` folder (`git clone XXX package`). Add your folder to `.gitignore`
 
-2. Amend Host Laravel `host/composer.json`
-
-Before:
-
-```json
-"repositories": {
-}
+2. Amend Host Laravel `host/composer.json` to point to freshly cloned package repository.
+Assuming your package name is _escolalms/packagename_, it can be done by invoking following command from within the container:
+```sh
+composer config repositories.escolalms/packagename '{ "type": "path", "url": "../packages/packagename" }'
 ```
-
-After:
-
-```json
-"repositories": {
-    "escolalms/headless-h5p": {
-        "type": "path",
-        "url": "../packages/headless-h5p"
-    }
-}
-```
-
-Example with 2 packages
-
-```json
-   "repositories": {
-        "escolalms/headless-h5p": {
-            "type": "path",
-            "url": "../packages/headless-h5p"
-        },
-        "escolalms/courses": {
-            "type": "path",
-            "url": "../packages/courses"
-        }
-    }
-```
-
-Note that name (`escolalms/headless-h5p` in example above) **MUST** match one you have in `package/composer.json`
 
 3. Enter bash (instruction above), then add you packge with `composer require escolalms/headless-h5p`
 


### PR DESCRIPTION
Currently readme describes editing package.json manually by replacing existing repositories and dependencies with our own.
My suggestion is to remove those and make use of `composer config` command instead. 